### PR TITLE
Refresh Tokens

### DIFF
--- a/src/DailyWire.Authentication/Services/TokenService.cs
+++ b/src/DailyWire.Authentication/Services/TokenService.cs
@@ -92,6 +92,11 @@ public class TokenService(ILogger<TokenService> logger, ITokenStore tokenStore, 
 
     private static bool ValidateAccessToken(AuthenticationTokens tokens)
     {
+        if (string.IsNullOrWhiteSpace(tokens.AccessToken))
+        {
+            return false;
+        }
+        
         var parameters = ValidationParameters.None;
 
         parameters.ValidateIssuedTime = true;

--- a/src/PodcastProxy.Web/DailyWirePodcastProxy.ini
+++ b/src/PodcastProxy.Web/DailyWirePodcastProxy.ini
@@ -18,7 +18,7 @@ FilePath = tokens.dat
 Issuer = authorize.dailywire.com
 Audience = https://api.dailywire.com/
 ClientId = FCgw3nA6cxkcXLVseAQvCSVBrymwvfpE
-Scope = openid,profile,email,offline_access
+Scope = openid profile offline_access
 
 [ConnectionStrings]
 Database = DataSource=podcasts.db


### PR DESCRIPTION
Fixed refreshing access token fails due to bad oauth scopes parameter formatting.