### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
+++ b/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
@@ -30,7 +30,11 @@ public class AuthKeyAuthorizationHandler(
             var keyMatches = string.Equals(authKey?.Trim(), authOptions.AccessKey.Trim(), StringComparison.Ordinal);
 
             logger.LogDebug("Authorization key matches: {KeyMatches}", keyMatches);
-            var sanitizedAuthKey = authKey?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            
+            var sanitizedAuthKey = authKey?.Replace(Environment.NewLine, "")
+                .Replace("\n", "")
+                .Replace("\r", "");
+            
             logger.LogTrace("Expected auth key: {ExpectedAuthKey}\n\tProvided auth key: {ProvidedAuthKey}", authOptions.AccessKey, sanitizedAuthKey);
 
             if (keyMatches)

--- a/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
+++ b/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
@@ -29,12 +29,11 @@ public class AuthKeyAuthorizationHandler(
             var authKey = httpContextAccessor.HttpContext.Request.Query["auth"].SingleOrDefault();
             var keyMatches = string.Equals(authKey?.Trim(), authOptions.AccessKey.Trim(), StringComparison.Ordinal);
 
-            logger.LogDebug("Authorization key matches: {KeyMatches}", keyMatches);
-            
             var sanitizedAuthKey = authKey?.Replace(Environment.NewLine, "")
                 .Replace("\n", "")
                 .Replace("\r", "");
             
+            logger.LogDebug("Authorization key matches: {KeyMatches}", keyMatches);
             logger.LogTrace("Expected auth key: {ExpectedAuthKey}\n\tProvided auth key: {ProvidedAuthKey}", authOptions.AccessKey, sanitizedAuthKey);
 
             if (keyMatches)

--- a/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
+++ b/src/PodcastProxy.Host/Authorization/AuthKeyAuthorizationHandler.cs
@@ -30,7 +30,8 @@ public class AuthKeyAuthorizationHandler(
             var keyMatches = string.Equals(authKey?.Trim(), authOptions.AccessKey.Trim(), StringComparison.Ordinal);
 
             logger.LogDebug("Authorization key matches: {KeyMatches}", keyMatches);
-            logger.LogTrace("Expected auth key: {ExpectedAuthKey}\n\tProvided auth key: {ProvidedAuthKey}", authOptions.AccessKey, authKey);
+            var sanitizedAuthKey = authKey?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            logger.LogTrace("Expected auth key: {ExpectedAuthKey}\n\tProvided auth key: {ProvidedAuthKey}", authOptions.AccessKey, sanitizedAuthKey);
 
             if (keyMatches)
             {
@@ -41,7 +42,7 @@ public class AuthKeyAuthorizationHandler(
             {
                 context.Fail();
                 logger.LogWarning("Authorization failed: Auth key parameter '{ProvidedAuthKey}' did not match '{ExpectedAuthKey}'\n\tRequest: {Request}",
-                    httpContextAccessor.HttpContext.Request.ToRequestLogLine(), authKey, authOptions.AccessKey);
+                    httpContextAccessor.HttpContext.Request.ToRequestLogLine(), sanitizedAuthKey, authOptions.AccessKey);
             }
         }
         else

--- a/src/PodcastProxy.Host/Extensions/HttpRequestExtensions.cs
+++ b/src/PodcastProxy.Host/Extensions/HttpRequestExtensions.cs
@@ -9,8 +9,13 @@ public static class HttpRequestExtensions
         var query = request.Query.Aggregate(string.Empty, (str, pair) =>
         {
             var separator = string.IsNullOrEmpty(str) ? '?' : '&';
-
-            return str + $"{separator}{pair.Key}={pair.Value}";
+            
+            var sanitizedValue = pair.Value.ToString()
+                .Replace(Environment.NewLine, "")
+                .Replace("\n", "")
+                .Replace("\r", "");
+            
+            return str + $"{separator}{pair.Key}={sanitizedValue}";
         });
 
         return $"{request.Method} {request.Scheme}://{request.Host}{request.Path}{query} {request.Protocol}";


### PR DESCRIPTION
Potential fix for [https://github.com/fpnewton/DailyWirePodcastProxy/security/code-scanning/1](https://github.com/fpnewton/DailyWirePodcastProxy/security/code-scanning/1)

To fix the problem, we need to sanitize the `authKey` before logging it. Since the log entries are plain text, we should remove any new line characters from the `authKey` to prevent log forging. This can be done using the `String.Replace` method to replace new line characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
